### PR TITLE
Remove hardcoded stuff

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -18,6 +18,10 @@ paginate = 10
 pygmentsCodefences = true
 pygmentsStyle = "native"
 
+# For https://webmention.io/
+webmention = ""
+pingback = ""
+
 # Taxonomies (only tags and categories are supported out of the box but you can
 # add more)
 [taxonomies]
@@ -68,6 +72,7 @@ pygmentsStyle = "native"
         # name = "@Jack_harkness"
     # [params.mastodon]
         # name = "@jkharkness"
+        # host = "scholar.social"
 
 
 # Sitemap location (default is /sitemap.xml)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -18,10 +18,6 @@ paginate = 10
 pygmentsCodefences = true
 pygmentsStyle = "native"
 
-# For https://webmention.io/
-webmention = ""
-pingback = ""
-
 # Taxonomies (only tags and categories are supported out of the box but you can
 # add more)
 [taxonomies]
@@ -76,6 +72,9 @@ pingback = ""
     
     # Enable link to feed in footer
     blogrss = true
+
+    # Enable pingback and webmention via webmention.io
+    webmention = "hugocisneros.com"
 
 
 # Sitemap location (default is /sitemap.xml)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -73,6 +73,9 @@ pingback = ""
     # [params.mastodon]
         # name = "@jkharkness"
         # host = "scholar.social"
+    
+    # Enable link to feed in footer
+    blogrss = true
 
 
 # Sitemap location (default is /sitemap.xml)

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,6 +8,7 @@
         </i></b>
         {{ end }}
         <div class="flex justify-between items-center">
+            {{ if not .Params.HideDate}}
             <a class="text-lg text-gray-600 dark:text-gray-400 border-none u-url" href="{{ .Permalink }}">
                 <time itemprop="datePublished" class="dt-published"
                     datetime="{{ .PublishDate.Format "2006-01-02T15:04:05Z0700" }}"
@@ -15,7 +16,10 @@
                     {{ .PublishDate.Format "02/01/2006" }}
                 </time>
             </a>
-            <a class="text-gray-600 dark:text-gray-400 text-right border-none p-author h-card" rel="author" href="{{ .Site.BaseURL }}" itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">Hugo Cisneros</span></a>
+            {{ end }}
+            {{ if .Params.Author }}
+            <a class="text-gray-600 dark:text-gray-400 text-right border-none p-author h-card" rel="author" href="{{ .Site.BaseURL }}" itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ .Params.Author }}</span></a>
+            {{ end }}
         </div>
         {{ if .Params.Readingtime }}
         <div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
     {{ if isset .Site.Params "blogrss" }}
     <li class="first:before:content-none before:content-['•'] inline-block list-none">
       <a class="rss-link inline-block text-neutral-800 dark:text-neutral-400 border-none"
-          href="{{ "/blog/index.xml" }}"
+          href="{{ .Site.BaseURL }}{{ "blog/index.xml" }}"
           type="application/rss+xml"
           target="_blank">
         {{ i18n "footerRSS" }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -77,9 +77,7 @@
 <meta name="theme-color" content="#ffffff">
 {{ if .Site.Params.Webmention }}
 <link rel="webmention" href="https://webmention.io/{{ .Site.Params.Webmention }}/webmention">
-{{ end }}
-{{ if .Site.Params.Pingback }}
-<link rel="pingback" href="https://webmention.io/{{ .Site.Params.Pingback }}/xmlrpc">
+<link rel="pingback" href="https://webmention.io/{{ .Site.Params.Webmention }}/xmlrpc">
 {{ end }}
 <!-- Common JS -->
 {{ $commonJs := resources.Get "js/common.js" | resources.Minify }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -73,6 +73,7 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/site.webmanifest">
+<link href="{{ .Site.BaseURL }}index.xml" type="application/atom+xml" rel="alternate" title="Sitewide Atom feed" />
 <meta name="theme-color" content="#ffffff">
 {{ if .Site.Params.Webmention }}
 <link rel="webmention" href="https://webmention.io/{{ .Site.Params.Webmention }}/webmention">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -53,7 +53,7 @@
 <meta name="twitter:creator" content="{{ .Site.Params.Twitter.Name }}">
 {{ end }}
 {{ if .Site.Params.Mastodon.Name }}
-<link rel="me" href="https://scholar.social/{{ .Site.Params.Mastodon.Name }}">
+<link rel="me" href="https://{{ .Site.Params.Mastodon.Host }}/{{ .Site.Params.Mastodon.Name }}">
 {{ end }}
 {{ if .Site.Params.Sameas }}
 <link rel="me" href="{{ .Site.Params.Sameas }}">
@@ -74,8 +74,12 @@
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/site.webmanifest">
 <meta name="theme-color" content="#ffffff">
-<link rel="webmention" href="https://webmention.io/hugocisneros.com/webmention">
-<link rel="pingback" href="https://webmention.io/hugocisneros.com/xmlrpc">
+{{ if .Site.Params.Webmention }}
+<link rel="webmention" href="https://webmention.io/{{ .Site.Params.Webmention }}/webmention">
+{{ end }}
+{{ if .Site.Params.Pingback }}
+<link rel="pingback" href="https://webmention.io/{{ .Site.Params.Pingback }}/xmlrpc">
+{{ end }}
 <!-- Common JS -->
 {{ $commonJs := resources.Get "js/common.js" | resources.Minify }}
 <script>{{ $commonJs.Content | safeJS }}</script>

--- a/layouts/partials/info.html
+++ b/layouts/partials/info.html
@@ -12,7 +12,7 @@
             <source srcset="{{ .Site.Params.imgname.Name }}"
                     {{ if .Site.Params.imgname.Type }} type="{{ .Site.Params.Imgname.Type }}"{{ end }}>
             <img class="main-image u-photo mx-auto"
-                 itemprop="contentUrl" alt="Main picture"
+            itemprop="contentUrl" alt="{{ .Site.Params.Imgname.Alt }}"
                  src="{{ .Site.Params.imgname.Name }}">
         </picture>
     </div>


### PR DESCRIPTION
Hey, 
i made a few changes to the theme and thought you might be interested.

This PR removes the hardcoded author, fixes the link to the atom feed in the footer (was broken if your base url is not "/"), adds a variable for the mastodon host, and adds a link to the atom feed in head to help feed readers find it.

Sorry that its all in one PR, i did not think about merging it back when i started.