### PR TITLE
Fix author list comma behavior

### DIFF
--- a/layouts/partials/publication.html
+++ b/layouts/partials/publication.html
@@ -10,16 +10,18 @@
              class="w-full"/>
     </div>
     <div class="publication grow shrink-2 basis-3/4 my-1.5 mx-2">
-        {{ range $author_index, $author_val := .authors }}
-        {{ if $author_val.me }}
-        <b>
-        {{ end }}
-            <span itemprop="author">{{- $author_val.name -}}</span>
-            {{- /* Add comma if not last author */ -}}
-            {{- if le $author_index (len .) -}},{{- end -}}
-        {{ if $author_val.me }}
-        </b>
-        {{ end }}
+        {{ with $authorlist := .authors }}
+            {{ range $author_index, $author_val := $authorlist }}
+            {{ if $author_val.me }}
+            <b>
+            {{ end }}
+                <span itemprop="author">{{- $author_val.name -}}</span>
+                {{- /* Add comma if not last author */ -}}
+                {{- if lt $author_index (sub (len $authorlist) 1) -}},{{- end -}}
+            {{ if $author_val.me }}
+            </b>
+            {{ end }}
+            {{ end }}
         {{ end }}
         <br>
         <b>


### PR DESCRIPTION
I noticed that the authors list in the publications element did not add commas as expected in some cases.

I believe the issue came from referencing the incorrect variable when iterating through the author list: https://github.com/hugcis/hugo-astatine-theme/blob/17f1644a8e5a3a9bd07c8900bd71061ffb3a38a7/layouts/partials/publication.html#L19

Since `.` in this scope refers to `author` elements, which have a `name` and optionally `me` values, it can only have a length of either 1 or 2. Instead, `.` should be replaced with a reference to the entire list of authors.

The pull request fixes the issue by creating a new variable `$authorlist`, which may have been what the conditional intended to reference. 